### PR TITLE
Create listreqs bash/shell script

### DIFF
--- a/listreqs.sh
+++ b/listreqs.sh
@@ -7,13 +7,14 @@ else
 	read -p "Enter the requirements file name : " file
 	if [ -z "$file" ];
 	then
-		touch requirements.txt
-		pip list > requirements.txt
 		file="requirements.txt"
 	fi
 
 fi
 
+touch $file
+pip list > $file
+
 sed -i '1,2d' $file
-sed -i 's/ \{2,\}/ /g' $file
+sed -i 's/ \{1,\}/ /g' $file
 sed -i 's/\ /==/g' $file

--- a/listreqs.sh
+++ b/listreqs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [ -n "$1" ];
+then
+	file=$1
+else
+	read -p "Enter the requirements file name : " file
+	if [ -z "$file" ];
+	then
+		touch requirements.txt
+		pip list > requirements.txt
+		file="requirements.txt"
+	fi
+
+fi
+
+sed -i '1,2d' $file
+sed -i 's/ \{2,\}/ /g' $file
+sed -i 's/\ /==/g' $file


### PR DESCRIPTION
Addressing the Issue #1 

Added a shell script that converts an `requirements.txt` file from a `list` format to a `freeze` format that can be in a downloadable format for pip.

Below is a quick demonstration.

![libreqs1](https://user-images.githubusercontent.com/40317114/136805935-ed7a07a2-8406-44e2-8ec6-50296cc9f7d1.gif)

Usage:
1. Can pass in as a positional(command line) argument:
```
bash listreqs.sh reqs.txt
```

2. Can input the file name from the prompt after running the shell script
```
bash listreqs.sh
Enter the requirements file name : reqs.txt
```

3. Not passing any input will lead to the creation of a default file called `requirements.txt`.
```
bash listreqs.sh
Enter the requirements file name : 
```

